### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
   qq: 2581502433@qq.com
   
-#特性
+# 特性
 1.  支持语音、表情、more，并且可以关闭、打开。
 2.  单个主题表情采用collectionView，节约内存空间。整体实现是ScrollView+collectionView
 3.  聊天输入框支持placehold
@@ -108,16 +108,16 @@
 }
 ```
 
-##控件里面的一些View可以自己定制，里面只是稍微演示
+## 控件里面的一些View可以自己定制，里面只是稍微演示
 `PanelBottomView`
 `OfficialAccountToolbar`
 
-##控件可以根据业务需要，更换业务模型
+## 控件可以根据业务需要，更换业务模型
 `MoreItem`  
 `ChatToolBarItem`  
 `FaceThemeModel`   
 `FaceSourceManager`   
 
-##感谢  
+## 感谢  
 `MessageDisplayKit`
 `JSQMessagesViewController`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
